### PR TITLE
Fix handling of the X-Inertia-Partial-Data header

### DIFF
--- a/flask_inertia/views.py
+++ b/flask_inertia/views.py
@@ -78,6 +78,10 @@ def render_inertia(
 
     inertia_version = get_asset_version()
     refresh_props = request.headers.getlist("X-Inertia-Partial-Data")
+    if len(refresh_props) == 1 and "," in refresh_props[0]:
+        refresh_props = list(
+            filter(None, request.headers.get("X-Inertia-Partial-Data", "").split(","))
+        )
     if (
         refresh_props
         and request.headers.get("X-Inertia-Partial-Component", "") == component_name


### PR DESCRIPTION
Hi!

Sorry for the unexpected contribution, but at work we rely on the flask-inertia server-side adapter for an important app and a while ago I notice that, at least when using a relatively recent version of the Vue client-side adapter, partial data (meaning, the value of the X-Inertia-Partial-Data HTTP header) is no longer the same header repeated as many times as the # of props the client asks to be refreshes, but merely as single, comma-separated string listing the subset of props that need to be "refreshed"
As I don't want to break existing functionality for anyone else who might be relying on it, I added a quick check to make sure that's what the client-side adapter asked for, and then continue the same as before.
Please let me know if there's anything else I need to do, or if you need further clarification on anything explained above.

Thank you for all the work you put on this awesome library - it's a true pleasure to work with.